### PR TITLE
Add GHAS via GHA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+
+/.github/workflows @AppDirect/devops-platform


### PR DESCRIPTION
Use shared GitHub Action to execute GHAS. Only Java, JavaScript and Go are currently processed. All other language are ignored. If you see this PR and your project is not with one of those language you should remove your project from checking GHAS workflow in the teams repository.
This is also the initial commit for opinionated CI and we will enable new feature over time via this shared action.